### PR TITLE
Add program settings frame

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,25 @@
+"""Program configuration storage."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict
+
+# Configuration stored in user's home directory
+CONFIG_PATH = Path.home() / ".vista_order_settings.json"
+
+
+def load_settings() -> Dict[str, str]:
+    """Load stored settings or return defaults."""
+    if CONFIG_PATH.exists():
+        try:
+            return json.loads(CONFIG_PATH.read_text())
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def save_settings(art_root: str) -> None:
+    """Persist program settings to disk."""
+    data = {"art_root": art_root}
+    CONFIG_PATH.write_text(json.dumps(data))

--- a/gui/main.py
+++ b/gui/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import customtkinter as ctk
 
 from config.credentials import load_credentials, save_credentials
+from config.settings import load_settings, save_settings
 from services.crimpress import login as crimpress_login
 
 
@@ -41,11 +42,32 @@ class MainWindow(ctk.CTk):
         self.password_entry.grid(row=2, column=1, sticky="w")
 
         # status indicator
-        self.status_indicator = ctk.CTkLabel(logins_frame, text="", width=12, height=12, fg_color="red", corner_radius=6)
+        self.status_indicator = ctk.CTkLabel(
+            logins_frame, text="", width=12, height=12, fg_color="red", corner_radius=6
+        )
         self.status_indicator.grid(row=1, column=2, rowspan=2, padx=10)
 
         save_button = ctk.CTkButton(logins_frame, text="Save", command=self._save_credentials)
         save_button.grid(row=3, column=0, columnspan=3, pady=(10, 0))
+
+        # Program settings frame
+        config_frame = ctk.CTkFrame(self.settings_tab)
+        config_frame.pack(padx=20, pady=(0, 20), fill="x")
+
+        ctk.CTkLabel(config_frame, text="Program Settings", font=("Helvetica", 16)).grid(
+            row=0, column=0, columnspan=2, pady=(0, 10)
+        )
+
+        ctk.CTkLabel(config_frame, text="Art Server Path:").grid(
+            row=1, column=0, sticky="e", padx=(0, 5)
+        )
+        self.art_path_entry = ctk.CTkEntry(config_frame, width=300)
+        self.art_path_entry.grid(row=1, column=1, sticky="w")
+
+        config_save = ctk.CTkButton(
+            config_frame, text="Save", command=self._save_program_settings
+        )
+        config_save.grid(row=2, column=0, columnspan=2, pady=(10, 0))
 
         # Load stored credentials if present
         email, password = load_credentials()
@@ -53,6 +75,11 @@ class MainWindow(ctk.CTk):
             self.email_entry.insert(0, email)
         if password:
             self.password_entry.insert(0, password)
+
+        settings = load_settings()
+        art_root = settings.get("art_root", "")
+        if art_root:
+            self.art_path_entry.insert(0, art_root)
 
     def _save_credentials(self) -> None:
         email = self.email_entry.get()
@@ -66,6 +93,10 @@ class MainWindow(ctk.CTk):
             self.status_indicator.configure(fg_color="green" if success else "red")
         else:
             self.status_indicator.configure(fg_color="red")
+
+    def _save_program_settings(self) -> None:
+        art_root = self.art_path_entry.get()
+        save_settings(art_root)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- allow saving user program settings in a JSON file
- add GUI frame for configuring art server path

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afa2e917f8832db657e89acb786fda