### PR TITLE
Add Crimpress login test button and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Vista Order Automation
+
+Vista Order Automation streamlines order ingestion across partner sites, our web portal and the art server.
+
+## Features
+- Graphical interface built with [CustomTkinter](https://github.com/TomSchimansky/CustomTkinter).
+- Command line tools powered by [Typer](https://typer.tiangolo.com/).
+- Secure credential storage via the system keyring.
+- Crimpress login verification with visual green/red status indicator.
+
+## Requirements
+- Python 3.10+
+- Dependencies from `requirements.txt`
+- Environment variable `CRIMPRESS_LOGIN_URL` pointing to the Crimpress login page.
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## GUI Usage
+Launch the interface:
+```bash
+python -m cli gui
+```
+1. Open the **Settings** tab.
+2. Enter Crimpress email and password.
+3. Click **Test** to attempt a real login. The indicator turns green on success or red on failure.
+4. Click **Save** to store credentials in the OS keyring.
+5. Set the art server path and save program settings.
+
+## CLI Usage
+- `python -m cli login` – test Crimpress login using stored credentials.
+- `python -m cli gui` – launch the GUI from the command line.
+
+Stored credentials can be cleared using your platform's keyring tools. Program settings are written to `~/.vista_order_settings.json`.

--- a/gui/main.py
+++ b/gui/main.py
@@ -47,8 +47,11 @@ class MainWindow(ctk.CTk):
         )
         self.status_indicator.grid(row=1, column=2, rowspan=2, padx=10)
 
+        test_button = ctk.CTkButton(logins_frame, text="Test", command=self._test_login)
+        test_button.grid(row=3, column=0, pady=(10, 0))
+
         save_button = ctk.CTkButton(logins_frame, text="Save", command=self._save_credentials)
-        save_button.grid(row=3, column=0, columnspan=3, pady=(10, 0))
+        save_button.grid(row=3, column=1, columnspan=2, pady=(10, 0))
 
         # Program settings frame
         config_frame = ctk.CTkFrame(self.settings_tab)
@@ -85,6 +88,11 @@ class MainWindow(ctk.CTk):
         email = self.email_entry.get()
         password = self.password_entry.get()
         save_credentials(email, password)
+        self._test_login()
+
+    def _test_login(self) -> None:
+        email = self.email_entry.get()
+        password = self.password_entry.get()
         if email and password:
             try:
                 success = crimpress_login(email, password)


### PR DESCRIPTION
## Summary
- add dedicated `Test` button in GUI to verify Crimpress credentials and update status light
- document project setup and usage in new README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afa4f78f70832d832940c10210768e