### PR TITLE
Add configurable Crimpress login URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Vista Order Automation streamlines order ingestion across partner sites, our web
 ## Requirements
 - Python 3.10+
 - Dependencies from `requirements.txt`
-- Environment variable `CRIMPRESS_LOGIN_URL` pointing to the Crimpress login page.
+- Crimpress login URL provided via the `CRIMPRESS_LOGIN_URL` environment variable or configured in the Settings tab (default URL is prefilled).
 
 Install dependencies:
 ```bash
@@ -25,9 +25,9 @@ python -m cli gui
 ```
 1. Open the **Settings** tab.
 2. Enter Crimpress email and password.
-3. Click **Test** to attempt a real login. The indicator turns green on success or red on failure.
-4. Click **Save** to store credentials in the OS keyring.
-5. Set the art server path and save program settings.
+3. Adjust the Crimpress login URL if needed and set the art server path.
+4. Click **Test** to attempt a real login. The indicator turns green on success or red on failure.
+5. Click **Save** to store credentials and program settings.
 
 ## CLI Usage
 - `python -m cli login` – test Crimpress login using stored credentials.

--- a/cli/main.py
+++ b/cli/main.py
@@ -5,6 +5,7 @@ import typer
 from rich.console import Console
 
 from config.credentials import load_credentials
+from config.settings import load_settings
 from gui.main import main as gui_main
 from services.crimpress import login as crimpress_login
 
@@ -25,8 +26,10 @@ def login() -> None:
     if not email or not password:
         console.print("Credentials not found", style="red")
         raise typer.Exit(code=1)
+    settings = load_settings()
+    login_url = settings.get("login_url", "")
     try:
-        success = crimpress_login(email, password)
+        success = crimpress_login(email, password, login_url)
     except Exception as exc:  # pragma: no cover - network errors
         console.print(f"Login failed: {exc}", style="red")
         raise typer.Exit(code=1)

--- a/config/settings.py
+++ b/config/settings.py
@@ -2,24 +2,37 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Dict
 
 # Configuration stored in user's home directory
 CONFIG_PATH = Path.home() / ".vista_order_settings.json"
 
+# Default Crimpress login URL
+DEFAULT_LOGIN_URL = (
+    "https://cimpress.auth0.com/login?state=hKFo2SBhNDRLNG9wTnVKRHFsY2ZMaUZuWlNJWUNEV3lfRVVocKFupWxvZ2luo3RpZ"
+    "NkgSUg0UW9abmQ1cmVXaHF5dWYyYjI5UUd6MXlkMDVnaXOjY2lk2SBKSk5XemRLSE9MNjhqZ2l2aDdMeVpXVU5PWFdVV2l0OQ&client=JJNWzdKHOL68jgivh7LyZWUNOXWUWit9&protocol=oauth2&responseType=id_token%20token&audience=https%3A%2F%2Fapi.cimpress.io%2F&scope=openid%20profile%20email%20user_id&redirect_uri=https%3A%2F%2Fpom.cimpress.io%2F&response_type=code&response_mode=query&nonce=M3FrNUVjMlNNNHJqQ1lzd3U3eHFCczVCOHk2SHMufkxIR0suVG1YaDVLeQ%3D%3D&code_challenge=JQjuE3t-CIHiQKdPyEFeM0Yn8UgaEoAA7PjKnT3k2Og&code_challenge_method=S256&auth0Client=eyJuYW1lIjoiYXV0aDAtc3BhLWpzIiwidmVyc2lvbiI6IjEuMjIuNiJ9"
+)
+
 
 def load_settings() -> Dict[str, str]:
     """Load stored settings or return defaults."""
+    data: Dict[str, str] = {}
     if CONFIG_PATH.exists():
         try:
-            return json.loads(CONFIG_PATH.read_text())
+            data = json.loads(CONFIG_PATH.read_text())
         except json.JSONDecodeError:
-            return {}
-    return {}
+            data = {}
+
+    if not data.get("login_url"):
+        env_url = os.environ.get("CRIMPRESS_LOGIN_URL")
+        data["login_url"] = env_url or DEFAULT_LOGIN_URL
+
+    return data
 
 
-def save_settings(art_root: str) -> None:
+def save_settings(art_root: str, login_url: str) -> None:
     """Persist program settings to disk."""
-    data = {"art_root": art_root}
+    data = {"art_root": art_root, "login_url": login_url}
     CONFIG_PATH.write_text(json.dumps(data))

--- a/gui/main.py
+++ b/gui/main.py
@@ -97,10 +97,16 @@ class MainWindow(ctk.CTk):
         self.art_path_entry = ctk.CTkEntry(config_frame, width=300)
         self.art_path_entry.grid(row=1, column=1, sticky="w")
 
+        ctk.CTkLabel(config_frame, text="Crimpress Login URL:").grid(
+            row=2, column=0, sticky="e", padx=(0, 5)
+        )
+        self.login_url_entry = ctk.CTkEntry(config_frame, width=300)
+        self.login_url_entry.grid(row=2, column=1, sticky="w")
+
         config_save = ctk.CTkButton(
             config_frame, text="Save", command=self._save_program_settings
         )
-        config_save.grid(row=2, column=0, columnspan=2, pady=(10, 0))
+        config_save.grid(row=3, column=0, columnspan=2, pady=(10, 0))
 
         # Load stored credentials if present
         email, password = load_credentials()
@@ -113,6 +119,9 @@ class MainWindow(ctk.CTk):
         art_root = settings.get("art_root", "")
         if art_root:
             self.art_path_entry.insert(0, art_root)
+        login_url = settings.get("login_url", "")
+        if login_url:
+            self.login_url_entry.insert(0, login_url)
 
     def _save_credentials(self) -> None:
         email = self.email_entry.get()
@@ -127,9 +136,10 @@ class MainWindow(ctk.CTk):
     def _test_login(self) -> None:
         email = self.email_entry.get()
         password = self.password_entry.get()
+        login_url = self.login_url_entry.get()
         if email and password:
             try:
-                success = crimpress_login(email, password)
+                success = crimpress_login(email, password, login_url)
                 print("Login test successful" if success else "Login test failed")
             except Exception as exc:
                 success = False
@@ -140,8 +150,9 @@ class MainWindow(ctk.CTk):
 
     def _save_program_settings(self) -> None:
         art_root = self.art_path_entry.get()
+        login_url = self.login_url_entry.get()
         try:
-            save_settings(art_root)
+            save_settings(art_root, login_url)
             print("Program settings saved")
         except Exception as exc:
             self._log_error(exc)

--- a/services/crimpress.py
+++ b/services/crimpress.py
@@ -11,15 +11,16 @@ from automation.selectors import (
     CRIMPRESS_PASSWORD_INPUT,
     CRIMPRESS_SUBMIT_BUTTON,
 )
+from config.settings import DEFAULT_LOGIN_URL
 
 console = Console()
-LOGIN_URL = os.environ.get("CRIMPRESS_LOGIN_URL", "")
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
-def login(email: str, password: str) -> bool:
+def login(email: str, password: str, login_url: str | None = None) -> bool:
     """Attempt to authenticate to Crimpress."""
-    if not LOGIN_URL:
+    url = login_url or os.environ.get("CRIMPRESS_LOGIN_URL") or DEFAULT_LOGIN_URL
+    if not url:
         raise ValueError("CRIMPRESS_LOGIN_URL not set")
 
     with sync_playwright() as pw:
@@ -27,7 +28,7 @@ def login(email: str, password: str) -> bool:
         context = browser.new_context()
         page = context.new_page()
         console.log("Navigating to Crimpress login")
-        page.goto(LOGIN_URL)
+        page.goto(url)
         page.fill(CRIMPRESS_EMAIL_INPUT, email)
         page.fill(CRIMPRESS_PASSWORD_INPUT, password)
         page.click(CRIMPRESS_SUBMIT_BUTTON)


### PR DESCRIPTION
## Summary
- allow configuring the Crimpress login URL via settings with a prefilled default
- add GUI field and CLI support to use the configured login URL
- update login helper to accept an explicit URL or fall back to env/default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afa76c2b70832d8377e9f03a4be54e