### PR TITLE
Add detailed POM selectors for login and orders

### DIFF
--- a/automation/selectors.py
+++ b/automation/selectors.py
@@ -7,14 +7,18 @@ CRIMPRESS_PASSWORD_INPUT = "input[name='password']"
 CRIMPRESS_SUBMIT_BUTTON = "button.auth0-lock-submit"
 
 # POM (Cimpress) login page selectors
-POM_USERNAME_INPUT = "input[name='username']"
-POM_PASSWORD_INPUT = "input[name='password']"
-POM_LOGIN_BUTTON = "button[type='submit']"
+POM_USERNAME_INPUT = "input[name='username']"  # Username field
+POM_PASSWORD_INPUT = "input[name='password']"  # Password field
+POM_SUBMIT_BUTTON = "button[type='submit']"  # Login submit button
 POM_TOTP_INPUT = "input[name='code']"
 POM_TOTP_SUBMIT = "button[type='submit']"
 
 # POM orders page selectors
-POM_ORDER_ROW = "div.order-row"
-POM_ORDER_ID = ".order-id"
-POM_ART_FILE_LINK = "a.art-download"
-POM_NEXT_BUTTON = "button[aria-label='Next page']"
+POM_ORDER_ROW = "div.order-row"  # Order row in list view
+POM_ORDER_ROW_ID_LABEL = ".order-row .order-id"  # Order ID label within a row
+POM_ORDER_CARD = "div.order-card"  # Order card in grid view
+POM_ORDER_CARD_ID_LABEL = ".order-card .order-id"  # Order ID label within a card
+POM_ART_DOWNLOAD_LINK = "a.art-download"  # Link to download art assets
+POM_ART_DOWNLOAD_BUTTON = "button.art-download"  # Button to download art assets
+POM_NEXT_PAGE_BUTTON = "button[aria-label='Next page']"  # Pagination next
+POM_PREV_PAGE_BUTTON = "button[aria-label='Previous page']"  # Pagination previous

--- a/vista_fetch.py
+++ b/vista_fetch.py
@@ -70,7 +70,7 @@ def _login(page: Page, username: str, password: str, secret: Optional[str]) -> N
     page.goto("https://pom.cimpress.io/")
     page.fill(selectors.POM_USERNAME_INPUT, username)
     page.fill(selectors.POM_PASSWORD_INPUT, password)
-    page.click(selectors.POM_LOGIN_BUTTON)
+    page.click(selectors.POM_SUBMIT_BUTTON)
     if secret:
         code = _totp_code(secret)
         page.fill(selectors.POM_TOTP_INPUT, code)
@@ -111,10 +111,10 @@ def main(
             if not rows:
                 break
             for row in rows:
-                oid = row.get_attribute("data-orderid") or row.query_selector(selectors.POM_ORDER_ID).inner_text().strip()
+                oid = row.get_attribute("data-orderid") or row.query_selector(selectors.POM_ORDER_ROW_ID_LABEL).inner_text().strip()
                 order_dir = Path("Vista") / oid
                 order_dir.mkdir(parents=True, exist_ok=True)
-                links = row.query_selector_all(selectors.POM_ART_FILE_LINK)
+                links = row.query_selector_all(selectors.POM_ART_DOWNLOAD_LINK)
                 for link in links:
                     url = link.get_attribute("href")
                     fname = order_dir / Path(url.split("/")[-1])
@@ -124,7 +124,7 @@ def main(
                     if downloaded:
                         files += 1
                 orders += 1
-            next_btn = page.query_selector(selectors.POM_NEXT_BUTTON)
+            next_btn = page.query_selector(selectors.POM_NEXT_PAGE_BUTTON)
             if not next_btn or "disabled" in (next_btn.get_attribute("class") or ""):
                 break
             next_btn.click()


### PR DESCRIPTION
## Summary
- Add selectors for POM username/password fields and login submit
- Add selectors for order rows/cards, art download controls, and pagination
- Update fetch script to use new selectors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0e5fca3d8832db760d091184b1e61