### PR TITLE
Refactor Vista order fetch via service helpers

### DIFF
--- a/services/pom.py
+++ b/services/pom.py
@@ -1,0 +1,122 @@
+"""Helpers for interacting with POM (Cimpress) portal."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import struct
+import time
+from pathlib import Path
+from typing import Iterator, Tuple
+
+import requests
+from playwright.sync_api import BrowserContext, ElementHandle, Page
+from rich.console import Console
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from automation import selectors
+
+console = Console()
+
+
+def _totp_code(secret: str) -> str:
+    """Generate a TOTP code for the given base32 secret."""
+    key = base64.b32decode(secret.upper())
+    counter = struct.pack(">Q", int(time.time()) // 30)
+    h = hmac.new(key, counter, hashlib.sha1).digest()
+    o = h[19] & 0x0F
+    token = (struct.unpack(">I", h[o:o + 4])[0] & 0x7FFFFFFF) % 10 ** 6
+    return f"{token:06d}"
+
+
+def _choose_nonclobber(path: Path) -> Path:
+    """Return a non-clobbering path by adding numeric suffix if needed."""
+    base = path
+    counter = 1
+    while path.exists():
+        path = base.with_name(f"{base.stem}-{counter}{base.suffix}")
+        counter += 1
+    return path
+
+
+def _same_size(path: Path, size: int) -> bool:
+    """Check if *path* exists and matches *size*."""
+    return path.exists() and path.stat().st_size == size
+
+
+@retry(wait=wait_exponential(multiplier=1, min=1, max=30), stop=stop_after_attempt(5))
+def _download_with_retry(url: str, dest: Path, session: requests.Session) -> bool:
+    """Download *url* to *dest* if needed; return True if downloaded."""
+    resp = session.get(url, stream=True, timeout=60)
+    resp.raise_for_status()
+    size = int(resp.headers.get("Content-Length", 0))
+    etag = resp.headers.get("ETag")
+    etag_file = dest.with_suffix(dest.suffix + ".etag")
+    if _same_size(dest, size) and etag and etag_file.exists() and etag_file.read_text() == etag:
+        return False
+    tmp = _choose_nonclobber(dest)
+    with open(tmp, "wb") as fh:
+        for chunk in resp.iter_content(chunk_size=8192):
+            fh.write(chunk)
+    if etag:
+        etag_file.write_text(etag)
+    return True
+
+
+def login(context: BrowserContext) -> None:
+    """Ensure we are authenticated to POM using environment credentials."""
+    username = os.getenv("POM_USERNAME")
+    password = os.getenv("POM_PASSWORD")
+    if not username or not password:
+        raise ValueError("POM_USERNAME and POM_PASSWORD must be set")
+    secret = os.getenv("POM_TOTP_SECRET")
+
+    page = context.new_page()
+    page.goto("https://pom.cimpress.io/")
+    page.fill(selectors.POM_USERNAME_INPUT, username)
+    page.fill(selectors.POM_PASSWORD_INPUT, password)
+    page.click(selectors.POM_SUBMIT_BUTTON)
+    if secret:
+        page.fill(selectors.POM_TOTP_INPUT, _totp_code(secret))
+        page.click(selectors.POM_TOTP_SUBMIT)
+    page.wait_for_load_state("networkidle")
+    page.close()
+
+
+def iter_orders(page: Page) -> Iterator[Tuple[str, ElementHandle]]:
+    """Yield ``(order_id, element)`` pairs for all orders across pages."""
+    while True:
+        page.wait_for_load_state("networkidle")
+        rows = page.query_selector_all(selectors.POM_ORDER_ROW)
+        for row in rows:
+            oid = row.get_attribute("data-orderid") or row.query_selector(
+                selectors.POM_ORDER_ROW_ID_LABEL
+            ).inner_text().strip()
+            yield oid, row
+        next_btn = page.query_selector(selectors.POM_NEXT_PAGE_BUTTON)
+        if not next_btn or "disabled" in (next_btn.get_attribute("class") or ""):
+            break
+        next_btn.click()
+
+
+def download_art(page: Page, order: ElementHandle, dest_dir: Path) -> int:
+    """Download all art assets for *order* into *dest_dir*.
+
+    Returns the number of files downloaded.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    links = order.query_selector_all(selectors.POM_ART_DOWNLOAD_LINK)
+    session = requests.Session()
+    count = 0
+    for link in links:
+        url = link.get_attribute("href")
+        if not url:
+            continue
+        fname = dest_dir / Path(url.split("/")[-1])
+        downloaded = _download_with_retry(url, fname, session)
+        action = "downloaded" if downloaded else "skipped"
+        console.log(f"{dest_dir.name}: {fname.name} {action}")
+        if downloaded:
+            count += 1
+    return count

--- a/vista_fetch.py
+++ b/vista_fetch.py
@@ -1,81 +1,22 @@
 """Fetch Vista orders and download art files."""
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
-import os
-import struct
-import time
 from pathlib import Path
-from typing import Optional
+import re
 
-import requests
 import typer
 from rich.console import Console
-from tenacity import retry, stop_after_attempt, wait_exponential
-from playwright.sync_api import Page, sync_playwright
+from playwright.sync_api import sync_playwright
 
-from automation import selectors
+from services.pom import login, iter_orders, download_art
 
 console = Console()
 app = typer.Typer(add_completion=False, help=__doc__)
 
 
-def _totp_code(secret: str) -> str:
-    """Generate a TOTP code for the given base32 secret."""
-    key = base64.b32decode(secret.upper())
-    counter = struct.pack(">Q", int(time.time()) // 30)
-    h = hmac.new(key, counter, hashlib.sha1).digest()
-    o = h[19] & 0x0F
-    token = (struct.unpack(">I", h[o:o + 4])[0] & 0x7FFFFFFF) % 10 ** 6
-    return f"{token:06d}"
-
-
-def choose_nonclobber(path: Path) -> Path:
-    """Return a non-clobbering path by adding numeric suffix if needed."""
-    base = path
-    counter = 1
-    while path.exists():
-        path = base.with_name(f"{base.stem}-{counter}{base.suffix}")
-        counter += 1
-    return path
-
-
-def same_size(path: Path, size: int) -> bool:
-    """Check if *path* exists and matches *size*."""
-    return path.exists() and path.stat().st_size == size
-
-
-@retry(wait=wait_exponential(multiplier=1, min=1, max=30), stop=stop_after_attempt(5))
-def download_with_retry(url: str, dest: Path, session: requests.Session) -> bool:
-    """Download *url* to *dest* if needed; return True if downloaded."""
-    resp = session.get(url, stream=True, timeout=60)
-    resp.raise_for_status()
-    size = int(resp.headers.get("Content-Length", 0))
-    etag = resp.headers.get("ETag")
-    etag_file = dest.with_suffix(dest.suffix + ".etag")
-    if same_size(dest, size) and etag and etag_file.exists() and etag_file.read_text() == etag:
-        return False
-    tmp = choose_nonclobber(dest)
-    with open(tmp, "wb") as fh:
-        for chunk in resp.iter_content(chunk_size=8192):
-            fh.write(chunk)
-    if etag:
-        etag_file.write_text(etag)
-    return True
-
-
-def _login(page: Page, username: str, password: str, secret: Optional[str]) -> None:
-    page.goto("https://pom.cimpress.io/")
-    page.fill(selectors.POM_USERNAME_INPUT, username)
-    page.fill(selectors.POM_PASSWORD_INPUT, password)
-    page.click(selectors.POM_SUBMIT_BUTTON)
-    if secret:
-        code = _totp_code(secret)
-        page.fill(selectors.POM_TOTP_INPUT, code)
-        page.click(selectors.POM_TOTP_SUBMIT)
-    page.wait_for_load_state("networkidle")
+def sanitize(name: str) -> str:
+    """Return filesystem-safe version of *name*."""
+    return re.sub(r"[^A-Za-z0-9_-]", "_", name)
 
 
 @app.command()
@@ -84,50 +25,23 @@ def main(
     storage: Path = typer.Option(Path("storage_state.json"), help="Storage state path"),
 ) -> None:
     """Login to POM and download all art files for new orders."""
-    username = os.getenv("POM_USERNAME")
-    password = os.getenv("POM_PASSWORD")
-    if not username or not password:
-        console.print("POM_USERNAME and POM_PASSWORD must be set", style="bold red")
-        raise typer.Exit(code=1)
-    secret = os.getenv("POM_TOTP_SECRET")
-
     orders = 0
     files = 0
 
     with sync_playwright() as pw:
         browser = pw.chromium.launch(headless=headless)
-        context = browser.new_context(storage_state=str(storage) if storage.exists() else None)
-        page = context.new_page()
+        context = browser.new_context(
+            storage_state=str(storage) if storage.exists() else None
+        )
         if not storage.exists():
-            _login(page, username, password, secret)
+            login(context)
             context.storage_state(path=str(storage))
-
+        page = context.new_page()
         page.goto("https://pom.cimpress.io/items?fulfillerId=n66hf65q8j&status=new")
-        session = requests.Session()
-
-        while True:
-            page.wait_for_load_state("networkidle")
-            rows = page.query_selector_all(selectors.POM_ORDER_ROW)
-            if not rows:
-                break
-            for row in rows:
-                oid = row.get_attribute("data-orderid") or row.query_selector(selectors.POM_ORDER_ROW_ID_LABEL).inner_text().strip()
-                order_dir = Path("Vista") / oid
-                order_dir.mkdir(parents=True, exist_ok=True)
-                links = row.query_selector_all(selectors.POM_ART_DOWNLOAD_LINK)
-                for link in links:
-                    url = link.get_attribute("href")
-                    fname = order_dir / Path(url.split("/")[-1])
-                    downloaded = download_with_retry(url, fname, session)
-                    action = "downloaded" if downloaded else "skipped"
-                    console.log(f"{oid}: {fname.name} {action}")
-                    if downloaded:
-                        files += 1
-                orders += 1
-            next_btn = page.query_selector(selectors.POM_NEXT_PAGE_BUTTON)
-            if not next_btn or "disabled" in (next_btn.get_attribute("class") or ""):
-                break
-            next_btn.click()
+        for order_id, element in iter_orders(page):
+            order_dir = Path("Vista") / sanitize(order_id)
+            files += download_art(page, element, order_dir)
+            orders += 1
         console.print(f"Processed {orders} orders and {files} files", style="bold")
 
 


### PR DESCRIPTION
## Summary
- Replace inline login and download logic with reusable POM service helpers
- Add `services.pom` module providing login, order iteration, and art download utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0e77f2498832db9c88c155a8aff9d