### PR TITLE
chore: add pyotp dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Vista Order Automation streamlines order ingestion across partner sites, our web
 
 ## Requirements
 - Python 3.10+
-- Dependencies from `requirements.txt`
+- Dependencies from `requirements.txt` (including `pyotp`)
 - Environment variable `CRIMPRESS_LOGIN_URL` pointing to the Crimpress login page.
 
 Install dependencies:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ playwright
 rich
 tenacity
 requests
+pyotp


### PR DESCRIPTION
## Summary
- include pyotp in dependencies and docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0ed5f2088832daa4704b57ac1fc30