### PR TITLE
feat: load env from file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+CRIMPRESS_LOGIN_URL=https://example.com/login

--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ Vista Order Automation streamlines order ingestion across partner sites, our web
 ## Requirements
 - Python 3.10+
 - Dependencies from `requirements.txt` (including `pyotp`)
-- Environment variable `CRIMPRESS_LOGIN_URL` pointing to the Crimpress login page.
+- Environment variable `CRIMPRESS_LOGIN_URL` pointing to the Crimpress login page. This variable may be stored in a `.env` file in the project root.
 
 Install dependencies:
 ```bash
 pip install -r requirements.txt
+```
+Create a `.env` file with the Crimpress login URL:
+```bash
+echo "CRIMPRESS_LOGIN_URL=https://<crimpress-login-page>" > .env
 ```
 
 ## GUI Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ rich
 tenacity
 requests
 pyotp
+python-dotenv

--- a/services/crimpress.py
+++ b/services/crimpress.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from dotenv import load_dotenv
 from tenacity import retry, stop_after_attempt, wait_fixed
 from playwright.sync_api import Error, sync_playwright
 from rich.console import Console
@@ -12,14 +13,16 @@ from automation.selectors import (
     CRIMPRESS_SUBMIT_BUTTON,
 )
 
+load_dotenv()
+
 console = Console()
-LOGIN_URL = os.environ.get("CRIMPRESS_LOGIN_URL", "")
 
 
 @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
 def login(email: str, password: str) -> bool:
     """Attempt to authenticate to Crimpress."""
-    if not LOGIN_URL:
+    login_url = os.environ.get("CRIMPRESS_LOGIN_URL")
+    if not login_url:
         raise ValueError("CRIMPRESS_LOGIN_URL not set")
 
     with sync_playwright() as pw:
@@ -28,7 +31,7 @@ def login(email: str, password: str) -> bool:
         try:
             page = context.new_page()
             console.log("Navigating to Crimpress login")
-            page.goto(LOGIN_URL)
+            page.goto(login_url)
             page.fill(CRIMPRESS_EMAIL_INPUT, email)
             page.fill(CRIMPRESS_PASSWORD_INPUT, password)
             page.click(CRIMPRESS_SUBMIT_BUTTON)


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file
- document `.env` usage for the Crimpress login URL

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0f31c8418832d8a79e97b63c5d959