### PR TITLE
Handle alternate POM login selectors

### DIFF
--- a/automation/selectors.py
+++ b/automation/selectors.py
@@ -8,6 +8,7 @@ CRIMPRESS_SUBMIT_BUTTON = "button.auth0-lock-submit"
 
 # POM (Cimpress) login page selectors
 POM_USERNAME_INPUT = "input[name='username']"  # Username field
+POM_EMAIL_INPUT = "input[name='email']"  # Fallback email field
 POM_PASSWORD_INPUT = "input[name='password']"  # Password field
 POM_SUBMIT_BUTTON = "button[type='submit']"  # Login submit button
 POM_TOTP_INPUT = "input[name='code']"


### PR DESCRIPTION
## Summary
- Support both username and email field names during POM login
- Add fallback email selector for POM auth page

## Testing
- `python -m py_compile services/pom.py automation/selectors.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0fd4a3a94832da0fd81bbc23f30b6